### PR TITLE
Add a compiled version of the Symfony router

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 # Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
 # You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
 # composer.lock
+_matcher.php

--- a/bench_compiled.php
+++ b/bench_compiled.php
@@ -1,0 +1,96 @@
+<?php
+
+use Symfony\Component\Routing\Matcher\CompiledUrlMatcher;
+use Symfony\Component\Routing\Matcher\Dumper\CompiledUrlMatcherDumper;
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$routePaths = [
+    'akaunting' => require(__DIR__ . '/routes/akaunting.php'),
+];
+
+/**
+ * @BeforeMethods({"init"})
+ */
+class RouterBench
+{
+    private $key;
+    private $fastRouteDispatcher;
+    private $symfonyUrlMatcher;
+
+    public function init($args)
+    {
+        $key = $args[0];
+
+        if ($key !== $this->key) {
+            $this->key = $key;
+        
+            global $routePaths;
+            $routePathDataset = $routePaths[$key];
+
+            // Initialize FastRoute
+            $this->fastRouteDispatcher = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) use ($routePathDataset) {
+                $i = 0;
+                foreach ($routePathDataset as $path) {
+                    $r->addRoute('GET', "/$path", "r$i");
+                    $i++;
+                }
+            });
+        
+            // Initialize Symfony
+            $routes = new \Symfony\Component\Routing\RouteCollection();
+            $i = 0;
+            foreach ($routePathDataset as $path) {
+                $route = new \Symfony\Component\Routing\Route("/$path");
+                $routes->add("r$i", $route);
+                $i++;
+            }
+
+            // Compile the url matcher
+            $matcherDumper = new CompiledUrlMatcherDumper($routes);
+            $matcherContent = $matcherDumper->dump();
+            file_put_contents(__DIR__.'/_matcher.php', $matcherContent);
+
+            $context = new \Symfony\Component\Routing\RequestContext();
+            $this->symfonyUrlMatcher = new CompiledUrlMatcher(require __DIR__.'/_matcher.php', $context);
+
+        }
+    }
+
+    /**
+     * @ParamProviders({"dataProvider"})
+     */
+    public function benchFastRoute($args)
+    {
+        $uri = $args[1];
+        $result = $this->fastRouteDispatcher->dispatch('GET', $uri);
+        return $result;
+    }
+
+    /**
+     * @ParamProviders({"dataProvider"})
+     */
+    public function benchSymfony($args)
+    {
+        $uri = $args[1];
+        try {
+            $result = $this->symfonyUrlMatcher->match($uri);
+            return $result;
+        } catch (\Throwable $t) {
+            return null;
+        }
+    }
+
+    public function dataProvider()
+    {
+        return [
+            'akaunting no match' => ['akaunting', '/F6kiIkhRvFXNWg/MHzKw6DyJA09CA/n3bMz2zLya4hTB'],
+            'akaunting first param' => ['akaunting', '/languages/de/back'],
+            'akaunting first static' => ['akaunting', '/offline-payments/settings'],
+            'akaunting middle param' => ['akaunting', '/purchases/vendors/abcdefghi/enable'],
+            'akaunting middle static' => ['akaunting', '/purchases/vendors/export'],
+            'akaunting last param' => ['akaunting', '/signed/invoices/123456789/confirm'],
+            'akaunting last static' => ['akaunting', '/portal/logout'],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "phpbench/phpbench": "^0.17.1"
     },
     "scripts": {
-        "bench": "phpbench run bench.php --report=env \"--report=generator:\\\"table\\\",cols:[\\\"subject\\\",\\\"set\\\",\\\"mean\\\",\\\"min\\\",\\\"max\\\",\\\"diff\\\"],sort:{set:\\\"asc\\\",subject:\\\"asc\\\"},break:[\\\"set\\\"]\" --revs=1 --iterations=10 --time-unit=\"milliseconds\""
+        "bench": "phpbench run bench.php --report=env \"--report=generator:\\\"table\\\",cols:[\\\"subject\\\",\\\"set\\\",\\\"mean\\\",\\\"min\\\",\\\"max\\\",\\\"diff\\\"],sort:{set:\\\"asc\\\",subject:\\\"asc\\\"},break:[\\\"set\\\"]\" --revs=1 --iterations=10 --time-unit=\"milliseconds\"",
+        "benchc": "phpbench run bench_compiled.php --report=env \"--report=generator:\\\"table\\\",cols:[\\\"subject\\\",\\\"set\\\",\\\"mean\\\",\\\"min\\\",\\\"max\\\",\\\"diff\\\"],sort:{set:\\\"asc\\\",subject:\\\"asc\\\"},break:[\\\"set\\\"]\" --revs=1 --iterations=10 --time-unit=\"milliseconds\""
     }
 }


### PR DESCRIPTION
In your benchmarks, you "point" the fact that FastRoute is way faster than Symfony Routing.

However, you forgot one critical point: the Symfony Routing component is better to be used when **compiled**. It is therefore highly optimized for runtime performance boosts.

See difference:

| Current benchmark | Benchmark with compiled Symfony UrlMatcher |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/3369266/108210864-585e3200-712c-11eb-9e01-ef349cfb5e3f.png) | ![image](https://user-images.githubusercontent.com/3369266/108211178-b0953400-712c-11eb-950e-1d1a72f8c435.png) |

All of a sudden, Symfony becomes **way faster** than FastRoute, except for the static part, but still, a compiled version of the UrlMatcher (which is the default in most Symfony-based apps) is much more performant.

This has some stuff to change the debate that takes place there: https://dev.to/brcontainer/teeny-a-route-system-for-php-4j23